### PR TITLE
[fe-20260404-0253599] Dynamic <html lang> attribute per locale

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
@@ -84,13 +85,22 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+const LANG_MAP: Record<string, string> = {
+  zh: "zh-TW",
+  en: "en",
+  ja: "ja",
+};
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = (await headers()).get("x-locale") ?? "zh";
+  const lang = LANG_MAP[locale] ?? "zh-TW";
+
   return (
-    <html lang="zh-TW" suppressHydrationWarning>
+    <html lang={lang} suppressHydrationWarning>
       <head>
         <ThemeScript />
       </head>

--- a/middleware.ts
+++ b/middleware.ts
@@ -43,8 +43,10 @@ export function middleware(req: NextRequest) {
   );
 
   if (pathnameLocale) {
-    // Update cookie to match current locale
-    const res = NextResponse.next();
+    // Update cookie to match current locale and pass locale to layout via request header
+    const headers = new Headers(req.headers);
+    headers.set("x-locale", pathnameLocale);
+    const res = NextResponse.next({ request: { headers } });
     res.cookies.set(COOKIE_NAME, pathnameLocale, { path: "/", maxAge: 60 * 60 * 24 * 365 });
     return res;
   }


### PR DESCRIPTION
Closes #6

## Summary
- Middleware now forwards detected locale via `x-locale` request header to the root layout
- Root layout reads `x-locale` and maps to BCP47 lang tags (`zh-TW`, `en`, `ja`)
- `<html lang>` is now dynamic instead of hardcoded to `zh-TW`

## Changes
- `middleware.ts`: Clone request headers, set `x-locale` before passing to `NextResponse.next()`
- `app/layout.tsx`: Add `LANG_MAP`, make `RootLayout` async, read header via `headers()`

## Acceptance Criteria
- [x] `/zh` pages render `<html lang="zh-TW">`
- [x] `/en` pages render `<html lang="en">`
- [x] `/ja` pages render `<html lang="ja">`
- [x] Root `/` (before redirect) defaults to `zh-TW`
- [x] No regression in existing layout (fonts, theme script, analytics)
- [x] Build passes

By agent `fe-20260404-0253599`.