### PR TITLE
[fe-20260404-0253599] Fix all internal links to include locale prefix

### DIFF
--- a/app/en/about/page.tsx
+++ b/app/en/about/page.tsx
@@ -108,7 +108,7 @@ export default function EnAboutPage() {
             <p className="text-base font-semibold" style={{ color: "var(--text)" }}>Questions? Let's talk.</p>
             <p className="text-sm mt-0.5" style={{ color: "var(--text-muted)" }}>English, Japanese, or Chinese — free consultation</p>
           </div>
-          <Link href="/contact" className="inline-flex items-center gap-2 px-7 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0" style={{ background: "var(--blue)" }}>
+          <Link href="/en/contact" className="inline-flex items-center gap-2 px-7 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0" style={{ background: "var(--blue)" }}>
             Contact us <ArrowRight size={15} weight="bold" />
           </Link>
         </div>

--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -71,10 +71,10 @@ export default function EnglishHomePage() {
           </p>
 
           <div className="flex flex-wrap gap-3">
-            <Link href="/contact" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white" style={{ background: "var(--blue)" }}>
+            <Link href="/en/contact" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white" style={{ background: "var(--blue)" }}>
               Free Consultation <ArrowRight size={16} weight="bold" />
             </Link>
-            <Link href="/properties" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border" style={{ borderColor: "oklch(80% 0.1 178 / 0.4)", color: "#F0FDFA" }}>
+            <Link href="/en/properties" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border" style={{ borderColor: "oklch(80% 0.1 178 / 0.4)", color: "#F0FDFA" }}>
               View Properties
             </Link>
           </div>
@@ -192,10 +192,10 @@ export default function EnglishHomePage() {
             Free consultation in English, Japanese, or Chinese. Tell us your needs and we'll match you.
           </p>
           <div className="flex flex-wrap gap-3 justify-center">
-            <Link href="/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm" style={{ background: "var(--card-bg)", color: "var(--blue)" }}>
+            <Link href="/en/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm" style={{ background: "var(--card-bg)", color: "var(--blue)" }}>
               Chat on LINE <ArrowRight size={16} weight="bold" />
             </Link>
-            <Link href="/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm border text-white" style={{ borderColor: "rgba(255,255,255,0.4)" }}>
+            <Link href="/en/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm border text-white" style={{ borderColor: "rgba(255,255,255,0.4)" }}>
               Send Email
             </Link>
           </div>

--- a/app/en/properties/page.tsx
+++ b/app/en/properties/page.tsx
@@ -69,7 +69,7 @@ export default function EnPropertiesPage() {
                   <div className="flex flex-wrap gap-1.5 mb-5">
                     {p.features.map((f) => <span key={f} className="text-[11px] px-2.5 py-1 rounded-md font-medium" style={{ background: "var(--surface)", color: "var(--teal)" }}>{f}</span>)}
                   </div>
-                  <Link href="/contact" className="flex w-full items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold text-white" style={{ background: "var(--blue)" }}>
+                  <Link href="/en/contact" className="flex w-full items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold text-white" style={{ background: "var(--blue)" }}>
                     Enquire about this property <ArrowRight size={15} weight="bold" />
                   </Link>
                 </div>
@@ -81,7 +81,7 @@ export default function EnPropertiesPage() {
               <h2 className="text-xl font-bold tracking-tight" style={{ color: "var(--text)" }}>Don't see what you need?</h2>
               <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>Tell us your requirements — we'll search across Zhubei and Hsinchu</p>
             </div>
-            <Link href="/contact" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0" style={{ background: "var(--blue)" }}>
+            <Link href="/en/contact" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0" style={{ background: "var(--blue)" }}>
               Tell us what you need <ArrowRight size={15} weight="bold" />
             </Link>
           </div>

--- a/app/en/services/page.tsx
+++ b/app/en/services/page.tsx
@@ -129,7 +129,7 @@ export default function EnServicesPage() {
             <h2 className="text-2xl font-bold tracking-tight" style={{ color: "var(--text)" }}>Free Consultation</h2>
             <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>English, Japanese, or Chinese — we speak your language</p>
           </div>
-          <Link href="/contact" className="inline-flex items-center gap-2 px-7 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0" style={{ background: "var(--blue)" }}>
+          <Link href="/en/contact" className="inline-flex items-center gap-2 px-7 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0" style={{ background: "var(--blue)" }}>
             Get in touch <ArrowRight size={16} weight="bold" />
           </Link>
         </div>

--- a/app/ja/page.tsx
+++ b/app/ja/page.tsx
@@ -70,10 +70,10 @@ export default function JapaneseHomePage() {
           </p>
 
           <div className="flex flex-wrap gap-3">
-            <Link href="/contact" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white" style={{ background: "var(--blue)" }}>
+            <Link href="/ja/contact" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white" style={{ background: "var(--blue)" }}>
               無料相談 <ArrowRight size={16} weight="bold" />
             </Link>
-            <Link href="/properties" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border" style={{ borderColor: "oklch(80% 0.1 178 / 0.4)", color: "#F0FDFA" }}>
+            <Link href="/ja/properties" className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border" style={{ borderColor: "oklch(80% 0.1 178 / 0.4)", color: "#F0FDFA" }}>
               物件を見る
             </Link>
           </div>
@@ -191,10 +191,10 @@ export default function JapaneseHomePage() {
             日本語・英語・中国語で無料相談承ります。ご要望をお聞かせください。
           </p>
           <div className="flex flex-wrap gap-3 justify-center">
-            <Link href="/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm" style={{ background: "var(--card-bg)", color: "var(--blue)" }}>
+            <Link href="/ja/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm" style={{ background: "var(--card-bg)", color: "var(--blue)" }}>
               LINEで相談 <ArrowRight size={16} weight="bold" />
             </Link>
-            <Link href="/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm border text-white" style={{ borderColor: "rgba(255,255,255,0.4)" }}>
+            <Link href="/ja/contact" className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm border text-white" style={{ borderColor: "rgba(255,255,255,0.4)" }}>
               メールで相談
             </Link>
           </div>

--- a/app/zh/about/page.tsx
+++ b/app/zh/about/page.tsx
@@ -164,7 +164,7 @@ export default function AboutPage() {
             <p className="text-base font-semibold" style={{ color: "var(--text)" }}>有問題嗎？直接聯絡我們。</p>
             <p className="text-sm mt-0.5" style={{ color: "var(--text-muted)" }}>英日中均可溝通，免費諮詢</p>
           </div>
-          <Link href="/contact"
+          <Link href="/zh/contact"
             className="inline-flex items-center gap-2 px-7 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0"
             style={{ background: "var(--blue)" }}>
             聯絡我們 <ArrowRight size={15} weight="bold" />

--- a/app/zh/blog/asml-employee-housing-hsinchu/page.tsx
+++ b/app/zh/blog/asml-employee-housing-hsinchu/page.tsx
@@ -198,7 +198,7 @@ export default function ASMLHousingGuide() {
             Free consultation in English, Japanese, or Chinese. We know what ASML expats need.
           </p>
           <a
-            href="/contact"
+            href="/zh/contact"
             className="inline-block bg-white text-indigo-700 px-8 py-3 rounded-xl font-bold hover:bg-indigo-50 transition-colors"
           >
             Get Free Consultation →

--- a/app/zh/blog/hsinchu-expat-housing-guide/page.tsx
+++ b/app/zh/blog/hsinchu-expat-housing-guide/page.tsx
@@ -268,7 +268,7 @@ export default function HsinchuExpatGuide() {
             易澤居 EasyRent 提供免費諮詢，英日中均可溝通。
           </p>
           <a
-            href="/contact"
+            href="/zh/contact"
             className="inline-block bg-white text-indigo-700 px-8 py-3 rounded-xl font-bold hover:bg-indigo-50 transition-colors"
           >
             免費諮詢 →

--- a/app/zh/blog/zhubei-expat-apartments/page.tsx
+++ b/app/zh/blog/zhubei-expat-apartments/page.tsx
@@ -175,7 +175,7 @@ export default function ZhubeiApartmentsGuide() {
           易澤居 EasyRent 在竹北兩大區域均有精選房源，免費為您配對。
         </p>
         <a
-          href="/properties"
+          href="/zh/properties"
           className="inline-block bg-white text-indigo-700 px-8 py-3 rounded-xl font-bold hover:bg-indigo-50 transition-colors"
         >
           查看精選房源 →

--- a/app/zh/page.tsx
+++ b/app/zh/page.tsx
@@ -165,7 +165,7 @@ export default function HomePage() {
 
           <div className="flex flex-wrap gap-3">
             <Link
-              href="/contact"
+              href="/zh/contact"
               className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white transition-colors"
               style={{ background: "var(--blue)" }}
             >
@@ -173,7 +173,7 @@ export default function HomePage() {
               <ArrowRight size={16} weight="bold" />
             </Link>
             <Link
-              href="/properties"
+              href="/zh/properties"
               className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold border transition-colors"
               style={{ borderColor: "oklch(80% 0.1 178 / 0.4)", color: "#F0FDFA", background: "transparent" }}
             >
@@ -329,7 +329,7 @@ export default function HomePage() {
                 深度內容，<br />幫你在新竹找到家
               </h2>
             </div>
-            <Link href="/blog"
+            <Link href="/zh/blog"
               className="hidden md:inline-flex items-center gap-1.5 text-sm font-medium transition-colors"
               style={{ color: "#5EEAD4" }}>
               查看全部 <ArrowRight size={16} weight="bold" />
@@ -405,13 +405,13 @@ export default function HomePage() {
             免費諮詢，英日中均可溝通。告訴我們您的需求，我們為您量身配對。
           </p>
           <div className="flex flex-wrap gap-3 justify-center">
-            <Link href="/contact"
+            <Link href="/zh/contact"
               className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm transition-colors"
               style={{ background: "var(--card-bg)", color: "var(--blue)" }}>
               LINE 免費諮詢
               <ArrowRight size={16} weight="bold" />
             </Link>
-            <Link href="/contact"
+            <Link href="/zh/contact"
               className="inline-flex items-center gap-2 px-7 py-3.5 rounded-lg font-semibold text-sm border transition-colors text-white"
               style={{ borderColor: "rgba(255,255,255,0.4)", background: "transparent" }}>
               Email 聯絡

--- a/app/zh/properties/page.tsx
+++ b/app/zh/properties/page.tsx
@@ -154,7 +154,7 @@ export default function PropertiesPage() {
                     ))}
                   </div>
 
-                  <Link href="/contact"
+                  <Link href="/zh/contact"
                     className="flex w-full items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold text-white transition-colors"
                     style={{ background: "var(--blue)" }}>
                     詢問這間房源
@@ -172,7 +172,7 @@ export default function PropertiesPage() {
               <h2 className="text-xl font-bold tracking-tight" style={{ color: "var(--text)" }}>找不到喜歡的？</h2>
               <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>告訴我們您的需求，竹北、新竹全都找</p>
             </div>
-            <Link href="/contact"
+            <Link href="/zh/contact"
               className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0"
               style={{ background: "var(--blue)" }}>
               說說你的需求 <ArrowRight size={15} weight="bold" />

--- a/app/zh/services/page.tsx
+++ b/app/zh/services/page.tsx
@@ -240,7 +240,7 @@ export default function ServicesPage() {
             <h2 className="text-2xl font-bold tracking-tight" style={{ color: "var(--text)" }}>立即免費諮詢</h2>
             <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>英日中均可，告訴我們您的需求</p>
           </div>
-          <Link href="/contact"
+          <Link href="/zh/contact"
             className="inline-flex items-center gap-2 px-7 py-3 rounded-lg text-sm font-semibold text-white flex-shrink-0"
             style={{ background: "var(--blue)" }}>
             免費諮詢

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
   const pathname = usePathname();
   const locale: Locale = pathname.startsWith("/en") ? "en" : pathname.startsWith("/ja") ? "ja" : "zh";
 
-  const logoHref = locale === "en" ? "/en" : locale === "ja" ? "/ja" : "/";
+  const logoHref = `/${locale}`;
 
   const tagline: Record<Locale, { main: string; sub: string }> = {
     zh: {
@@ -34,23 +34,23 @@ export default function Footer() {
 
   const navLinks: Record<Locale, { href: string; label: string }[]> = {
     zh: [
-      { href: "/services", label: "代管服務" },
-      { href: "/properties", label: "精選房源" },
-      { href: "/blog", label: "租屋指南" },
-      { href: "/about", label: "關於我們" },
-      { href: "/contact", label: "聯絡我們" },
+      { href: "/zh/services", label: "代管服務" },
+      { href: "/zh/properties", label: "精選房源" },
+      { href: "/zh/blog", label: "租屋指南" },
+      { href: "/zh/about", label: "關於我們" },
+      { href: "/zh/contact", label: "聯絡我們" },
     ],
     en: [
       { href: "/en/services", label: "Services" },
       { href: "/en/properties", label: "Properties" },
-      { href: "/blog", label: "Guides" },
+      { href: "/en/blog", label: "Guides" },
       { href: "/en/about", label: "About" },
       { href: "/en/contact", label: "Contact" },
     ],
     ja: [
       { href: "/ja/services", label: "サービス" },
       { href: "/ja/properties", label: "物件" },
-      { href: "/blog", label: "ガイド" },
+      { href: "/ja/blog", label: "ガイド" },
       { href: "/ja/about", label: "会社概要" },
       { href: "/ja/contact", label: "お問い合わせ" },
     ],

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -89,7 +89,7 @@ export default function Header() {
             {/* Language switcher */}
             <div className="hidden md:flex items-center gap-1.5 text-xs font-medium">
               <Link
-                href="/"
+                href="/zh"
                 className="transition-colors"
                 style={{ color: locale === "zh" ? "#0F766E" : "#9CA3AF", fontWeight: locale === "zh" ? 700 : 500 }}
               >
@@ -118,7 +118,7 @@ export default function Header() {
 
             {/* CTA */}
             <Link
-              href={locale === "en" ? "/en/contact" : locale === "ja" ? "/ja/contact" : "/contact"}
+              href={`/${locale}/contact`}
               className="hidden md:inline-flex items-center text-[13.5px] font-semibold px-4 py-2 rounded-lg text-white transition-colors"
               style={{ background: "#0369A1" }}
             >
@@ -156,13 +156,13 @@ export default function Header() {
             ))}
             {/* Mobile language switcher */}
             <div className="flex items-center gap-3 px-3 py-2 text-xs font-medium">
-              <Link href="/" style={{ color: locale === "zh" ? "#0F766E" : "#9CA3AF" }} onClick={() => setOpen(false)}>中文</Link>
+              <Link href="/zh" style={{ color: locale === "zh" ? "#0F766E" : "#9CA3AF" }} onClick={() => setOpen(false)}>中文</Link>
               <Link href="/en" style={{ color: locale === "en" ? "#0F766E" : "#9CA3AF" }} onClick={() => setOpen(false)}>English</Link>
               <Link href="/ja" style={{ color: locale === "ja" ? "#0F766E" : "#9CA3AF" }} onClick={() => setOpen(false)}>日本語</Link>
             </div>
             <div className="pt-1">
               <Link
-                href={locale === "en" ? "/en/contact" : locale === "ja" ? "/ja/contact" : "/contact"}
+                href={`/${locale}/contact`}
                 className="block text-center py-2.5 text-sm font-semibold rounded-lg text-white"
                 style={{ background: "#0369A1" }}
                 onClick={() => setOpen(false)}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -8,7 +8,7 @@ export const localeNames: Record<Locale, string> = {
 };
 
 export const localePaths: Record<Locale, string> = {
-  zh: "/",
+  zh: "/zh",
   en: "/en",
   ja: "/ja",
 };


### PR DESCRIPTION
Closes #7

## Summary
- Added locale prefix to all internal links across Header, Footer, and page CTAs
- zh links: `/zh/...`, en links: `/en/...`, ja links: `/ja/...`
- Updated `lib/i18n.ts` `localePaths.zh` from `/` to `/zh`
- 15 files changed, all pure path substitutions

## Files changed
- `components/Header.tsx` — zh lang switcher `/` → `/zh`, CTA uses template literal
- `components/Footer.tsx` — zh logo `/` → `/zh`, all zh/en/ja nav links prefixed
- `lib/i18n.ts` — `localePaths.zh: "/"` → `"/zh"`
- `app/en/page.tsx` — 4 CTA links prefixed with `/en`
- `app/ja/page.tsx` — 4 CTA links prefixed with `/ja`
- `app/zh/page.tsx` — 5 CTA links prefixed with `/zh`
- 6 sub-pages (services, properties, about, blog articles) — `/contact` and `/properties` prefixed

## Acceptance Criteria
- [x] No internal link points to a path without locale prefix
- [x] zh links use `/zh/...`, en use `/en/...`, ja use `/ja/...`
- [x] Language switcher zh button → `/zh`
- [x] Footer logo (zh) → `/zh`
- [x] All CTA buttons use correct locale prefix
- [x] Build passes

By agent `fe-20260404-0253599`.