### PR TITLE
[fe-20260404-0253599] SEO fixes — hreflang, sitemap, canonical, OG image, robots

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://www.easyrents.xyz/en",
     languages: {
-      "zh-TW": "https://www.easyrents.xyz",
+      "zh-TW": "https://www.easyrents.xyz/zh",
       "en-US": "https://www.easyrents.xyz/en",
       "ja-JP": "https://www.easyrents.xyz/ja",
     },

--- a/app/ja/page.tsx
+++ b/app/ja/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://www.easyrents.xyz/ja",
     languages: {
-      "zh-TW": "https://www.easyrents.xyz",
+      "zh-TW": "https://www.easyrents.xyz/zh",
       "en-US": "https://www.easyrents.xyz/en",
       "ja-JP": "https://www.easyrents.xyz/ja",
     },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,7 @@ export const metadata: Metadata = {
       "新竹最專業的外商租屋代管服務。英日中三語，竹科外派人員首選。",
     images: [
       {
-        url: "/og-image.png",
+        url: "https://www.easyrents.xyz/og-image.png",
         width: 1200,
         height: 630,
         alt: "易澤居 EasyRent - 新竹外商租屋專家",
@@ -75,9 +75,9 @@ export const metadata: Metadata = {
     },
   },
   alternates: {
-    canonical: "https://www.easyrents.xyz",
+    canonical: "https://www.easyrents.xyz/zh",
     languages: {
-      "zh-TW": "https://www.easyrents.xyz",
+      "zh-TW": "https://www.easyrents.xyz/zh",
       "en-US": "https://www.easyrents.xyz/en",
       "ja-JP": "https://www.easyrents.xyz/ja",
     },

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,77 +4,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://www.easyrents.xyz";
 
   return [
-    // EN sub-pages
+    // ZH pages
+    { url: `${baseUrl}/zh`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 1 },
+    { url: `${baseUrl}/zh/services`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.9 },
+    { url: `${baseUrl}/zh/properties`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
+    { url: `${baseUrl}/zh/contact`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
+    { url: `${baseUrl}/zh/about`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.7 },
+    { url: `${baseUrl}/zh/blog`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
+    { url: `${baseUrl}/zh/blog/hsinchu-expat-housing-guide`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.9 },
+    { url: `${baseUrl}/zh/blog/zhubei-expat-apartments`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
+    { url: `${baseUrl}/zh/blog/asml-employee-housing-hsinchu`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.9 },
+
+    // EN pages
+    { url: `${baseUrl}/en`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
     { url: `${baseUrl}/en/services`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
     { url: `${baseUrl}/en/properties`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
     { url: `${baseUrl}/en/contact`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
     { url: `${baseUrl}/en/about`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.7 },
-    // Language roots
-    {
-      url: `${baseUrl}/en`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/ja`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    },
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/services`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/properties`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/contact`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/blog`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/blog/hsinchu-expat-housing-guide`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/blog/zhubei-expat-apartments`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/blog/asml-employee-housing-hsinchu`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.9,
-    },
+
+    // JA pages
+    { url: `${baseUrl}/ja`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
+    { url: `${baseUrl}/ja/services`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
+    { url: `${baseUrl}/ja/properties`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
+    { url: `${baseUrl}/ja/contact`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
+    { url: `${baseUrl}/ja/about`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.7 },
   ];
 }

--- a/app/zh/page.tsx
+++ b/app/zh/page.tsx
@@ -16,7 +16,14 @@ export const metadata: Metadata = {
   title: "易澤居 EasyRent | 新竹外商租屋專家 | 竹科外派住宅服務",
   description:
     "新竹最專業的外商租屋代管服務。英語・日語・中文三語全程服務，專為 ASML、竹科外派人員量身打造。竹北高鐵特區精選住宅，入住保障，與 Relocation Agent 深度合作。",
-  alternates: { canonical: "https://www.easyrents.xyz" },
+  alternates: {
+    canonical: "https://www.easyrents.xyz/zh",
+    languages: {
+      "zh-TW": "https://www.easyrents.xyz/zh",
+      "en-US": "https://www.easyrents.xyz/en",
+      "ja-JP": "https://www.easyrents.xyz/ja",
+    },
+  },
 };
 
 const features = [

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: "https://www.easyrents.xyz",
-  generateRobotsTxt: true,
+  generateRobotsTxt: false,
   generateIndexSitemap: false,
   alternateRefs: [
     {


### PR DESCRIPTION
Closes #8

## Summary
- Added hreflang alternates to zh page metadata (was the only locale missing them)
- Fixed zh canonical URL from `https://www.easyrents.xyz` to `https://www.easyrents.xyz/zh`
- Rewrote sitemap.ts with all locale-prefixed URLs, added missing ja sub-pages
- Made OG image URL absolute (`https://www.easyrents.xyz/og-image.png`)
- Disabled next-sitemap `generateRobotsTxt` to avoid conflict with `app/robots.ts`
- Fixed zh-TW hreflang URL in en/ja/root layout metadata to point to `/zh`

## Acceptance Criteria
- [x] All 3 locale pages have correct hreflang alternates
- [x] Sitemap contains only canonical URLs (no redirecting paths)
- [x] Sitemap includes ja sub-pages
- [x] OG image URL is absolute
- [x] No duplicate robots.txt generation
- [x] zh canonical points to /zh
- [x] Build passes

By agent `fe-20260404-0253599`.