### PR TITLE
[fe-20260404-0253599] Playwright E2E tests + i18n routing suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
 
 # next.js
 /.next/

--- a/e2e/core-paths.spec.ts
+++ b/e2e/core-paths.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+const locales = ["zh", "en", "ja"] as const;
+
+test.describe("core user paths", () => {
+  for (const locale of locales) {
+    test.describe(`${locale} locale`, () => {
+      test("homepage loads successfully", async ({ page }) => {
+        const response = await page.goto(`/${locale}`);
+        expect(response?.status()).toBeLessThan(400);
+        await expect(page.locator("header")).toBeVisible();
+        await expect(page.locator("footer")).toBeVisible();
+      });
+
+      test("header nav links are clickable", async ({ page }) => {
+        await page.goto(`/${locale}`);
+        const navLinks = page.locator("header nav a");
+        const count = await navLinks.count();
+        expect(count).toBeGreaterThan(0);
+
+        // Verify each nav link has an href
+        for (let i = 0; i < count; i++) {
+          const href = await navLinks.nth(i).getAttribute("href");
+          expect(href).toBeTruthy();
+        }
+      });
+
+      test("footer links are clickable", async ({ page }) => {
+        await page.goto(`/${locale}`);
+        const footerLinks = page.locator("footer a");
+        const count = await footerLinks.count();
+        expect(count).toBeGreaterThan(0);
+      });
+    });
+  }
+
+  test("dark mode toggle works", async ({ page }) => {
+    await page.goto("/zh");
+    const html = page.locator("html");
+
+    // Find and click the dark mode toggle button
+    const themeToggle = page.locator("button").filter({ has: page.locator("svg") }).first();
+
+    // Click until dark class appears (may start in system/light mode)
+    const initialHasDark = await html.evaluate((el) => el.classList.contains("dark"));
+
+    // Click the toggle
+    await themeToggle.click();
+    await page.waitForTimeout(300); // wait for theme transition
+
+    const afterClickHasDark = await html.evaluate((el) => el.classList.contains("dark"));
+
+    // The class should have toggled
+    expect(afterClickHasDark).not.toBe(initialHasDark);
+  });
+
+  test("CTA button exists and links to contact", async ({ page }) => {
+    await page.goto("/en");
+    // Find CTA links (Free Consultation or similar)
+    const ctaLinks = page.locator('a:has-text("Free Consultation")');
+    const count = await ctaLinks.count();
+    expect(count).toBeGreaterThan(0);
+    // Verify at least one links to contact page
+    const href = await ctaLinks.first().getAttribute("href");
+    expect(href).toContain("contact");
+  });
+});

--- a/e2e/i18n-routing.spec.ts
+++ b/e2e/i18n-routing.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("i18n routing", () => {
+  test.describe("locale detection from Accept-Language", () => {
+    test("/ with Accept-Language: zh → redirect to /zh", async ({ browser }) => {
+      const context = await browser.newContext({ locale: "zh-TW" });
+      const page = await context.newPage();
+      await page.goto("/");
+      expect(page.url()).toContain("/zh");
+      await context.close();
+    });
+
+    test("/ with Accept-Language: en → redirect to /en", async ({ browser }) => {
+      const context = await browser.newContext({ locale: "en-US" });
+      const page = await context.newPage();
+      await page.goto("/");
+      expect(page.url()).toContain("/en");
+      await context.close();
+    });
+
+    test("/ with Accept-Language: ja → redirect to /ja", async ({ browser }) => {
+      const context = await browser.newContext({ locale: "ja-JP" });
+      const page = await context.newPage();
+      await page.goto("/");
+      expect(page.url()).toContain("/ja");
+      await context.close();
+    });
+  });
+
+  test.describe("locale content verification", () => {
+    test("/en contains English content", async ({ page }) => {
+      await page.goto("/en");
+      await expect(page.locator("body")).toContainText("Your Home");
+      await expect(page.locator("body")).toContainText("in Hsinchu");
+    });
+
+    test("/ja contains Japanese content", async ({ page }) => {
+      await page.goto("/ja");
+      await expect(page.locator("body")).toContainText("竹科駐在員向け");
+    });
+
+    test("/zh contains Chinese content", async ({ page }) => {
+      await page.goto("/zh");
+      await expect(page.locator("body")).toContainText("竹科外派人員首選");
+    });
+  });
+
+  test.describe("NEXT_LOCALE cookie", () => {
+    test("NEXT_LOCALE cookie is set after visiting /en", async ({ page }) => {
+      await page.goto("/en");
+      const cookies = await page.context().cookies();
+      const localeCookie = cookies.find((c) => c.name === "NEXT_LOCALE");
+      expect(localeCookie).toBeDefined();
+      expect(localeCookie!.value).toBe("en");
+    });
+
+    test("cookie NEXT_LOCALE=en → / redirects to /en", async ({ browser }) => {
+      const context = await browser.newContext();
+      await context.addCookies([
+        { name: "NEXT_LOCALE", value: "en", domain: "localhost", path: "/" },
+      ]);
+      const page = await context.newPage();
+      await page.goto("/");
+      expect(page.url()).toContain("/en");
+      await context.close();
+    });
+  });
+
+  test.describe("language switcher", () => {
+    test("clicking EN on /zh navigates to /en", async ({ page, isMobile }) => {
+      await page.goto("/zh");
+      if (isMobile) {
+        // Open hamburger menu first
+        const menuButton = page.locator('button[aria-label="Toggle menu"]');
+        await menuButton.click();
+        const enLink = page.locator("header a").filter({ hasText: "English" }).first();
+        await enLink.click();
+      } else {
+        const enLink = page.locator("header a").filter({ hasText: "EN" }).first();
+        await enLink.click();
+      }
+      await page.waitForURL("**/en", { timeout: 10000 });
+      expect(page.url()).toContain("/en");
+    });
+  });
+
+  test.describe("invalid locale", () => {
+    test("/fr redirects to default locale", async ({ browser }) => {
+      const context = await browser.newContext({ locale: "zh-TW" });
+      const page = await context.newPage();
+      await page.goto("/fr");
+      const url = page.url();
+      expect(url).toMatch(/\/(zh|en|ja)/);
+      await context.close();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "19.2.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1246,6 +1247,22 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3643,6 +3660,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5396,6 +5428,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "postbuild": "next-sitemap",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
@@ -16,6 +17,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3456",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "Desktop Chrome",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "Mobile Safari",
+      use: { ...devices["iPhone 13"], viewport: { width: 375, height: 812 } },
+    },
+    {
+      name: "Tablet",
+      use: { viewport: { width: 768, height: 1024 }, deviceScaleFactor: 2 },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --port 3456",
+    url: "http://localhost:3456",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
Closes #4

## Summary
- Installed `@playwright/test` as devDependency
- Created `playwright.config.ts` with 3 projects: Desktop Chrome, Mobile Safari (375px), Tablet (768px)
- Added `test:e2e` script to package.json
- Created `e2e/` directory with two test suites

## Test Suites

### e2e/i18n-routing.spec.ts (10 tests)
- Accept-Language detection → redirect to correct locale (zh/en/ja)
- Locale content verification (/en has English, /ja has Japanese, /zh has Chinese)
- NEXT_LOCALE cookie set after visit, cookie-based redirect
- Language switcher navigation (desktop + mobile hamburger menu)
- Invalid locale (/fr) → redirect to default locale

### e2e/core-paths.spec.ts (11 tests)
- Homepage loads successfully for each locale (3 tests)
- Header nav links are clickable (3 tests)
- Footer links are clickable (3 tests)
- Dark mode toggle works
- CTA button exists and links to contact

## Results
- **63 tests total** (21 per project × 3 projects)
- **All passing** across Desktop Chrome, Mobile Safari, Tablet
- Dev server on port 3456 (3000/3100 occupied by OrbStack)

## Notes
- Nav links to unbuilt pages (services, properties, etc.) are tested for existence only, not 200 status
- CTA test checks for "contact" in href (tolerant of missing locale prefix on main)

By agent `fe-20260404-0253599`.